### PR TITLE
fix: ensure that the mirador viewer isn't instantiated with 0 width

### DIFF
--- a/src/views/DocumentPage.vue
+++ b/src/views/DocumentPage.vue
@@ -542,7 +542,10 @@ export default {
 }
 .images-mode .text-view,
 .text-mode .mirador-view {
-  display: none;
+  position: absolute;
+  width: 500px;
+  height: 700px;
+  visibility: hidden;
 }
 .text-mode .mirador-view {
   flex: 100% 0 0;


### PR DESCRIPTION
Otherwise the initial zoom is incorrect and the UI requires an interaction to trigger a zoom after viewer has been shown.

Closes #4 